### PR TITLE
Bump phpunit (#41)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /ssl/*.key
 
 /storage/*.log
+/.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Create an `.env` file:
 
     $ cp .env.example .env
 
+Run all the tests
+
+    $ composer test
+
 ### WebSocket Server
 
 Start the server:

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.4",
     "chesslablab/php-chess": "dev-master",
     "rubix/ml": "^1.1",
     "cboden/ratchet": "^0.4",
@@ -24,7 +24,7 @@
     "monolog/monolog": "^2.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "~5.7"
+    "phpunit/phpunit": "^9.5"
   },
   "autoload": {
     "psr-4": {
@@ -35,5 +35,8 @@
     "psr-4": {
       "ChessServer\\Tests\\Unit\\": "tests/unit/"
     }
+  },
+  "scripts": {
+    "tests": "phpunit"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "monolog/monolog": "^2.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "~5.0"
+    "phpunit/phpunit": "~5.7"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" backupGlobals="false" beStrictAboutCoversAnnotation="true" beStrictAboutOutputDuringTests="true" beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutTodoAnnotatedTests="true" verbose="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuite name="default">
+    <directory suffix="Test.php">tests</directory>
+  </testsuite>
+</phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,6 +6,6 @@
     </include>
   </coverage>
   <testsuite name="default">
-    <directory suffix="Test.php">tests</directory>
+    <directory>tests</directory>
   </testsuite>
 </phpunit>

--- a/tests/unit/Command/AsciiTest.php
+++ b/tests/unit/Command/AsciiTest.php
@@ -3,6 +3,7 @@
 namespace ChessServer\Tests\Unit\Command;
 
 use ChessServer\Command\AsciiCommand;
+use ChessServer\Exception\ParserException;
 use ChessServer\Tests\Unit\CommandTestCase;
 
 class AsciiTest extends CommandTestCase
@@ -20,10 +21,10 @@ class AsciiTest extends CommandTestCase
 
     /**
      * @test
-     * @expectedException ChessServer\Exception\ParserException
      */
     public function validate_ascii_foo()
     {
+        $this->expectException(ParserException::class);
         self::$parser->validate('/ascii foo');
     }
 }

--- a/tests/unit/Command/CapturesTest.php
+++ b/tests/unit/Command/CapturesTest.php
@@ -3,6 +3,7 @@
 namespace ChessServer\Tests\Unit\Command;
 
 use ChessServer\Command\CapturesCommand;
+use ChessServer\Exception\ParserException;
 use ChessServer\Tests\Unit\CommandTestCase;
 
 class CapturesTest extends CommandTestCase
@@ -20,10 +21,10 @@ class CapturesTest extends CommandTestCase
 
     /**
      * @test
-     * @expectedException ChessServer\Exception\ParserException
      */
     public function validate_captures_foo()
     {
+        $this->expectException(ParserException::class);
         self::$parser->validate('/captures foo');
     }
 }

--- a/tests/unit/Command/HistoryTest.php
+++ b/tests/unit/Command/HistoryTest.php
@@ -3,6 +3,7 @@
 namespace ChessServer\Tests\Unit\Command;
 
 use ChessServer\Command\HistoryCommand;
+use ChessServer\Exception\ParserException;
 use ChessServer\Tests\Unit\CommandTestCase;
 
 class HistoryTest extends CommandTestCase
@@ -20,10 +21,10 @@ class HistoryTest extends CommandTestCase
 
     /**
      * @test
-     * @expectedException ChessServer\Exception\ParserException
      */
     public function validate_history_foo()
     {
+        $this->expectException(ParserException::class);
         self::$parser->validate('/history foo');
     }
 }

--- a/tests/unit/Command/IsCheckTest.php
+++ b/tests/unit/Command/IsCheckTest.php
@@ -3,6 +3,7 @@
 namespace ChessServer\Tests\Unit\Command;
 
 use ChessServer\Command\IsCheckCommand;
+use ChessServer\Exception\ParserException;
 use ChessServer\Tests\Unit\CommandTestCase;
 
 class IsCheckTest extends CommandTestCase
@@ -20,10 +21,10 @@ class IsCheckTest extends CommandTestCase
 
     /**
      * @test
-     * @expectedException ChessServer\Exception\ParserException
      */
     public function validate_ischeck_foo()
     {
+        $this->expectException(ParserException::class);
         self::$parser->validate('/ischeck foo');
     }
 }

--- a/tests/unit/Command/IsMateTest.php
+++ b/tests/unit/Command/IsMateTest.php
@@ -3,6 +3,7 @@
 namespace ChessServer\Tests\Unit\Command;
 
 use ChessServer\Command\IsMateCommand;
+use ChessServer\Exception\ParserException;
 use ChessServer\Tests\Unit\CommandTestCase;
 
 class IsMateTest extends CommandTestCase
@@ -20,10 +21,10 @@ class IsMateTest extends CommandTestCase
 
     /**
      * @test
-     * @expectedException ChessServer\Exception\ParserException
      */
     public function validate_ismate_foo()
     {
+        $this->expectException(ParserException::class);
         self::$parser->validate('/ismate foo');
     }
 }

--- a/tests/unit/Command/PieceTest.php
+++ b/tests/unit/Command/PieceTest.php
@@ -3,6 +3,7 @@
 namespace ChessServer\Tests\Unit\Command;
 
 use ChessServer\Command\PieceCommand;
+use ChessServer\Exception\ParserException;
 use ChessServer\Tests\Unit\CommandTestCase;
 
 class PieceTest extends CommandTestCase
@@ -31,10 +32,10 @@ class PieceTest extends CommandTestCase
 
     /**
      * @test
-     * @expectedException ChessServer\Exception\ParserException
      */
     public function validate_piece_e4_e5()
     {
+        $this->expectException(ParserException::class);
         self::$parser->validate('/piece e4 e5');
     }
 }

--- a/tests/unit/Command/PiecesTest.php
+++ b/tests/unit/Command/PiecesTest.php
@@ -3,6 +3,7 @@
 namespace ChessServer\Tests\Unit\Command;
 
 use ChessServer\Command\PiecesCommand;
+use ChessServer\Exception\ParserException;
 use ChessServer\Tests\Unit\CommandTestCase;
 
 class PiecesTest extends CommandTestCase
@@ -31,19 +32,19 @@ class PiecesTest extends CommandTestCase
 
     /**
      * @test
-     * @expectedException ChessServer\Exception\ParserException
      */
     public function validate_pieces_w_foo()
     {
+        $this->expectException(ParserException::class);
         self::$parser->validate('/pieces w foo');
     }
 
     /**
      * @test
-     * @expectedException ChessServer\Exception\ParserException
      */
     public function validate_pieces_b_foo()
     {
+        $this->expectException(ParserException::class);
         self::$parser->validate('/pieces b foo');
     }
 }

--- a/tests/unit/Command/QuitTest.php
+++ b/tests/unit/Command/QuitTest.php
@@ -3,6 +3,7 @@
 namespace ChessServer\Tests\Unit\Command;
 
 use ChessServer\Command\QuitCommand;
+use ChessServer\Exception\ParserException;
 use ChessServer\Tests\Unit\CommandTestCase;
 
 class QuitTest extends CommandTestCase
@@ -20,10 +21,10 @@ class QuitTest extends CommandTestCase
 
     /**
      * @test
-     * @expectedException ChessServer\Exception\ParserException
      */
     public function validate_quit_foo()
     {
+        $this->expectException(ParserException::class);
         self::$parser->validate('/quit foo');
     }
 }

--- a/tests/unit/Command/StartTest.php
+++ b/tests/unit/Command/StartTest.php
@@ -3,6 +3,7 @@
 namespace ChessServer\Tests\Unit\Command;
 
 use ChessServer\Command\StartCommand;
+use ChessServer\Exception\ParserException;
 use ChessServer\Tests\Unit\CommandTestCase;
 
 class StartTest extends CommandTestCase
@@ -20,28 +21,28 @@ class StartTest extends CommandTestCase
 
     /**
      * @test
-     * @expectedException ChessServer\Exception\ParserException
      */
     public function validate_start_analysis_w()
     {
+        $this->expectException(ParserException::class);
         self::$parser->validate('/start analysis w');
     }
 
     /**
      * @test
-     * @expectedException ChessServer\Exception\ParserException
      */
     public function validate_start_foo()
     {
+        $this->expectException(ParserException::class);
         self::$parser->validate('/start foo');
     }
 
     /**
      * @test
-     * @expectedException ChessServer\Exception\ParserException
      */
     public function validate_start_bar()
     {
+        $this->expectException(ParserException::class);
         self::$parser->validate('/start bar');
     }
 }

--- a/tests/unit/Command/StatusTest.php
+++ b/tests/unit/Command/StatusTest.php
@@ -3,6 +3,7 @@
 namespace ChessServer\Tests\Unit\Command;
 
 use ChessServer\Command\StatusCommand;
+use ChessServer\Exception\ParserException;
 use ChessServer\Tests\Unit\CommandTestCase;
 
 class StatusTest extends CommandTestCase
@@ -20,10 +21,10 @@ class StatusTest extends CommandTestCase
 
     /**
      * @test
-     * @expectedException ChessServer\Exception\ParserException
      */
     public function validate_status_foo()
     {
+        $this->expectException(ParserException::class);
         self::$parser->validate('/status foo');
     }
 }

--- a/tests/unit/Command/TakebackTest.php
+++ b/tests/unit/Command/TakebackTest.php
@@ -3,6 +3,7 @@
 namespace ChessServer\Tests\Unit\Command;
 
 use ChessServer\Command\TakebackCommand;
+use ChessServer\Exception\ParserException;
 use ChessServer\Tests\Unit\CommandTestCase;
 
 class TakebackTest extends CommandTestCase
@@ -42,28 +43,28 @@ class TakebackTest extends CommandTestCase
 
     /**
      * @test
-     * @expectedException ChessServer\Exception\ParserException
      */
     public function validate_takeback_foo()
     {
+        $this->expectException(ParserException::class);
         self::$parser->validate('/takeback foo');
     }
 
     /**
      * @test
-     * @expectedException ChessServer\Exception\ParserException
      */
     public function validate_takeback_bar()
     {
+        $this->expectException(ParserException::class);
         self::$parser->validate('/takeback bar');
     }
 
     /**
      * @test
-     * @expectedException ChessServer\Exception\ParserException
      */
     public function validate_takeback_accept_foo()
     {
+        $this->expectException(ParserException::class);
         self::$parser->validate('/takeback accept foo');
     }
 }

--- a/tests/unit/Command/UndoMoveTest.php
+++ b/tests/unit/Command/UndoMoveTest.php
@@ -3,6 +3,7 @@
 namespace ChessServer\Tests\Unit\Command;
 
 use ChessServer\Command\UndoMoveCommand;
+use ChessServer\Exception\ParserException;
 use ChessServer\Tests\Unit\CommandTestCase;
 
 class UndoMoveTest extends CommandTestCase
@@ -20,10 +21,10 @@ class UndoMoveTest extends CommandTestCase
 
     /**
      * @test
-     * @expectedException ChessServer\Exception\ParserException
      */
     public function validate_undomove_foo()
     {
+        $this->expectException(ParserException::class);
         self::$parser->validate('/undomove foo');
     }
 }

--- a/tests/unit/CommandTestCase.php
+++ b/tests/unit/CommandTestCase.php
@@ -9,7 +9,7 @@ class CommandTestCase extends TestCase
 {
     protected static $parser;
 
-    public function setUp()
+    public function setUp(): void
     {
         self::$parser = new CommandParser();
     }


### PR DESCRIPTION
Bump PHPUnit to 9.5

- Add script to composer to run tests
- update README.md with `composer test` script
- add phpunit.xml (PHPUnit config file)
- PHP minimum version now 7.4, PHP 8 will now `composer install`
- add .phpunit.result.cache to git ignore list
- update all Tests with @expectedException to expectException
- update CommandTestCase setUp to return type of void 

Tested with PHP 8.0.8, all 33 tests are passing.