### PR TITLE
Arranged if commands in alphabetical order

### DIFF
--- a/src/Socket.php
+++ b/src/Socket.php
@@ -90,6 +90,25 @@ class Socket implements MessageComponentInterface
                     'message' =>  'This friend request could not be accepted.',
                 ],
             ]);
+        } elseif (is_a($cmd, DrawCommand::class)) {
+            if (is_a($gameMode, PlayFriendMode::class)) {
+                return $this->sendToMany(
+                    $gameMode->getResourceIds(),
+                    $gameMode->res($this->parser->argv, $cmd)
+                );
+            }
+        } elseif (is_a($cmd, PlayFenCommand::class)) {
+            if (is_a($gameMode, PlayFriendMode::class)) {
+                return $this->sendToMany(
+                    $gameMode->getResourceIds(),
+                    $gameMode->res($this->parser->argv, $cmd)
+                );
+            } elseif ($gameMode) {
+                return $this->sendToOne(
+                    $from->resourceId,
+                    $this->gameModes[$from->resourceId]->res($this->parser->argv, $cmd)
+                );
+            }
         } elseif (is_a($cmd, QuitCommand::class)) {
             if ($gameMode) {
                 unset($this->gameModes[$from->resourceId]);
@@ -100,6 +119,13 @@ class Socket implements MessageComponentInterface
             return $this->sendToOne($from->resourceId, [
                 $cmd->name => 'A game needs to be started first for this command to be allowed.',
             ]);
+        } elseif (is_a($cmd, ResignCommand::class)) {
+            if (is_a($gameMode, PlayFriendMode::class)) {
+                return $this->sendToMany(
+                    $gameMode->getResourceIds(),
+                    $gameMode->res($this->parser->argv, $cmd)
+                );
+            }
         } elseif (is_a($cmd, StartCommand::class)) {
             if ($gameMode) {
                 return $this->sendToOne($from->resourceId, [
@@ -153,33 +179,7 @@ class Socket implements MessageComponentInterface
                 ];
             }
             return $this->sendToOne($from->resourceId, $res);
-        } elseif (is_a($cmd, PlayFenCommand::class)) {
-            if (is_a($gameMode, PlayFriendMode::class)) {
-                return $this->sendToMany(
-                    $gameMode->getResourceIds(),
-                    $gameMode->res($this->parser->argv, $cmd)
-                );
-            } elseif ($gameMode) {
-                return $this->sendToOne(
-                    $from->resourceId,
-                    $this->gameModes[$from->resourceId]->res($this->parser->argv, $cmd)
-                );
-            }
         } elseif (is_a($cmd, TakebackCommand::class)) {
-            if (is_a($gameMode, PlayFriendMode::class)) {
-                return $this->sendToMany(
-                    $gameMode->getResourceIds(),
-                    $gameMode->res($this->parser->argv, $cmd)
-                );
-            }
-        } elseif (is_a($cmd, DrawCommand::class)) {
-            if (is_a($gameMode, PlayFriendMode::class)) {
-                return $this->sendToMany(
-                    $gameMode->getResourceIds(),
-                    $gameMode->res($this->parser->argv, $cmd)
-                );
-            }
-        } elseif (is_a($cmd, ResignCommand::class)) {
             if (is_a($gameMode, PlayFriendMode::class)) {
                 return $this->sendToMany(
                     $gameMode->getResourceIds(),


### PR DESCRIPTION
## Description:
I have completed the following tasks as mentioned the issue
- [x] The commands used in the main `if` block in [`ChessServer\Socket`](https://github.com/chesslablab/chess-server/blob/master/src/Socket.php) should be ordered alphabetically for better readability.

## Related Issue:
Closes #52 
