### PR TITLE
draft ratchet/ws server #261

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,13 @@ JWT_SECRET=password
 UID=1000
 GID=1000
 
+# wss.php
 WSS_ADDRESS=0.0.0.0
 WSS_PORT=8443
 
 WSS_ALLOWED_SCHEME=https
 WSS_ALLOWED_HOST=ui.chesslablab.org
+
+# ws.php
+WS_ADDRESS=0.0.0.0
+WS_PORT=8085

--- a/cli/ratchet/ws.php
+++ b/cli/ratchet/ws.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ChessServer\Cli\Ratchet;
+
+use ChessServer\Socket\RatchetClientStorage;
+use ChessServer\Socket\RatchetWebSocket;
+use Dotenv\Dotenv;
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Ratchet\Http\HttpServer;
+use Ratchet\Http\OriginCheck;
+use Ratchet\Server\IoServer;
+use Ratchet\WebSocket\WsServer;
+
+require __DIR__  . '/../../vendor/autoload.php';
+
+$dotenv = Dotenv::createImmutable(__DIR__.'/../../');
+$dotenv->load();
+
+$logger = new Logger('log');
+$logger->pushHandler(new StreamHandler(__DIR__.'/../../storage' . '/pchess.log', Logger::INFO));
+
+$clientStorage = new RatchetClientStorage($logger);
+
+$webSocket = (new RatchetWebSocket())->init($clientStorage);
+
+$ioServer = IoServer::factory(
+    new HttpServer(
+        new WsServer(
+            $webSocket
+        )
+    ),
+    $_ENV['WS_PORT'],
+    $_ENV['WS_ADDRESS']
+);
+
+$ioServer->run();


### PR DESCRIPTION
my implementation of ws server #261

few notes before merge:

1. I didn't found how to make allowed hosts filter, so this option not implemented (because my server open for third-party connections) - people can just extend this implementation for their personal needs.

2. Added few separated config options to the `.env.example` - even it could be common for WS/WSS

3. Created `ws.php` instead of `dev.php` like in previous version - I think it's more clear for beginners. 

4. it works, but I still getting #256
maybe forgot to upgrade something..