### PR TITLE
feat: removing the chess games from the log

### DIFF
--- a/src/Socket/RatchetClientStorage.php
+++ b/src/Socket/RatchetClientStorage.php
@@ -43,7 +43,7 @@ class RatchetClientStorage extends \SplObjectStorage implements ClientStorageInt
                 $this->current()->send(json_encode($res));
                 $this->logger->info('Sent message', [
                     'id' => $id,
-                    'cmd' => $res,
+                    'cmd' => array_keys($res),
                 ]);
             }
             $this->next();
@@ -58,7 +58,7 @@ class RatchetClientStorage extends \SplObjectStorage implements ClientStorageInt
                 $this->current()->send(json_encode($res));
                 $this->logger->info('Sent message', [
                     'ids' => $ids,
-                    'cmd' => $res,
+                    'cmd' => array_keys($res),
                 ]);
             }
             $this->next();

--- a/src/Socket/WorkermanClientStorage.php
+++ b/src/Socket/WorkermanClientStorage.php
@@ -43,7 +43,7 @@ class WorkermanClientStorage extends \SplObjectStorage implements ClientStorageI
                 $this->current()->send(json_encode($res));
                 $this->logger->info('Sent message', [
                     'id' => $id,
-                    'cmd' => $res,
+                    'cmd' => array_keys($res),
                 ]);
             }
             $this->next();
@@ -58,7 +58,7 @@ class WorkermanClientStorage extends \SplObjectStorage implements ClientStorageI
                 $this->current()->send(json_encode($res));
                 $this->logger->info('Sent message', [
                     'ids' => $ids,
-                    'cmd' => $res,
+                    'cmd' => array_keys($res),
                 ]);
             }
             $this->next();


### PR DESCRIPTION
Closes #272 

I just wanted to clarify something related to storing the games. Considering that the `sendToMany` and `sendToOne` methods are being called by many commands, do we want to stop storing logs only for prominent commands like: `/play_lan` which as per my analysis stores the fen data, so technically does this command mean chess games in the Issue description, or other commands like `/stockfish`, `/online_games`, etc logs be also stopped. However, my original idea based on analysis was to only stop logs for certain commands like `/play_lan` which can be conditionally received from `$res`. but for the sake of simplicity, for now, stopping logs for all commands.