### PR TITLE
Update StatsPlayerCommand.php

### DIFF
--- a/src/Command/Data/StatsPlayerCommand.php
+++ b/src/Command/Data/StatsPlayerCommand.php
@@ -3,7 +3,6 @@
 namespace ChessServer\Command\Data;
 
 use ChessServer\Command\AbstractCommand;
-use ChessServer\Command\Data\Pdo;
 use ChessServer\Socket\ChesslaBlabSocket;
 
 class StatsPlayerCommand extends AbstractCommand


### PR DESCRIPTION
Any class that stay in the same namespace, don't need the `use`.
Automatically it will call the class from the same namespace.