### PR TITLE
Add license link to ReadME

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Read the latest docs [here](https://chesslablab.github.io/chess-server/).
 
 ### License
 
-The PHP Chess Server is open-sourced software licensed under the MIT license.
+The PHP Chess Server is open-sourced software licensed under the [MIT license](https://github.com/chesslablab/chess-server/blob/main/LICENSE).
 
 ### Contributions
 


### PR DESCRIPTION
Add the license link to the ReadME, as is uniform with other repositories.